### PR TITLE
Add error alerts for folder_with_pdbs .pdb error

### DIFF
--- a/helper_scripts/parse_multiple_chains.py
+++ b/helper_scripts/parse_multiple_chains.py
@@ -5,6 +5,7 @@ def main(args):
     import numpy as np
     import os, time, gzip, json
     import glob 
+    import sys
     
     folder_with_pdbs_path = args.input_path
     save_path = args.output_path
@@ -99,7 +100,10 @@ def main(args):
     
     pdb_dict_list = []
     c = 0
-    
+
+    if folder_with_pdbs_path[-4:]==".pdb":
+        sys.exit("Error in Submission Script: The fixed positions options require a folder with pdb's be passed in, not a pdb filename. Please rectifiy the \"folder_with_pdbs\" variable in your submission script.")
+
     if folder_with_pdbs_path[-1]!='/':
         folder_with_pdbs_path = folder_with_pdbs_path+'/'
     


### PR DESCRIPTION
**Issue:**
If the folder_with_pdbs variable in the submission script for a fixed residues run was set to equal the path of a pdb rather than a folder containing pdb's, the full program would run without having any files to run on and without alerting the user to the nature of the problem. This made identifying the lack of output difficult. 
**Previous handling:**
None
**New handling:**
Detect ".pdb" in variable name and output "The fixed positions options require a folder with pdb's be passed in, not a pdb filename. Please rectifiy the "folder_with_pdbs" variable in your submission script." to the terminal. 
**Justification for handling choices:**
Rather than make a large change that could have unintended consequences downstream of the variable, an error alert to the user will assist in directing them how to properly use the code.