### PR TITLE
Fix for issue #92 - Adding proline

### DIFF
--- a/helper_scripts/parse_multiple_chains.py
+++ b/helper_scripts/parse_multiple_chains.py
@@ -41,6 +41,10 @@ def main(args):
       output: (length, atoms, coords=(x,y,z)), sequence
       '''
       xyz,seq,min_resn,max_resn = {},{},1e6,-1e6
+
+      res_idx = 0
+      last_res = "NOTHING"
+        
       for line in open(x,"rb"):
         line = line.decode("utf-8","ignore").rstrip()
     
@@ -56,11 +60,12 @@ def main(args):
             resn = line[22:22+5].strip()
             x,y,z = [float(line[i:(i+8)]) for i in [30,38,46]]
     
-            if resn[-1].isalpha(): 
-                resa,resn = resn[-1],int(resn[:-1])-1
-            else: 
-                resa,resn = "",int(resn)-1
-    #         resn = int(resn)
+            if resn != last_res:
+               res_idx += 1
+               last_res = resn
+               
+            resa,resn = "",res_idx
+
             if resn < min_resn: 
                 min_resn = resn
             if resn > max_resn: 

--- a/protein_mpnn_utils.py
+++ b/protein_mpnn_utils.py
@@ -82,6 +82,10 @@ def parse_PDB_biounits(x, atoms=['N','CA','C'], chain=None):
     return ["".join([aa_N_1.get(a,"-") for a in y]) for y in x]
 
   xyz,seq,min_resn,max_resn = {},{},1e6,-1e6
+
+  res_idx = 0
+  last_res = "NOTHING"
+  
   for line in open(x,"rb"):
     line = line.decode("utf-8","ignore").rstrip()
 
@@ -97,11 +101,12 @@ def parse_PDB_biounits(x, atoms=['N','CA','C'], chain=None):
         resn = line[22:22+5].strip()
         x,y,z = [float(line[i:(i+8)]) for i in [30,38,46]]
 
-        if resn[-1].isalpha(): 
-            resa,resn = resn[-1],int(resn[:-1])-1
-        else: 
-            resa,resn = "",int(resn)-1
-#         resn = int(resn)
+        if resn != last_res:
+               res_idx += 1
+               last_res = resn
+               
+        resa,resn = "",res_idx
+
         if resn < min_resn: 
             min_resn = resn
         if resn > max_resn: 


### PR DESCRIPTION
Fix for PDB files that have IMGT numbering.   Issue #92 

The original code ends up adding/removing residues when it runs into a residue number of "112A" or "34A". 

To fix, I just renumber the residues whenever the label changes. So they'll be just 1 to N residues.

It would be better if we first run the PDB file through some tools that fixes the PDB and renumbers it with only integer values. However, I didn't want to change too much of the code just in case other things might break.